### PR TITLE
Apply java plugin automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The following example configures a project to use the Smithy Gradle plugin:
 
 ```kotlin
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 ```
@@ -96,7 +95,6 @@ The following example `build.gradle.kts` will build a Smithy model using a
 
 ```kotlin
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 
@@ -137,7 +135,6 @@ build that uses the "external" projection.
 
 ```kotlin
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/adds-tags/build.gradle.kts
+++ b/examples/adds-tags/build.gradle.kts
@@ -1,7 +1,6 @@
 // This examples adds a Smithy tag to the built JAR.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/disable-jar/build.gradle.kts
+++ b/examples/disable-jar/build.gradle.kts
@@ -1,7 +1,6 @@
 // This example builds Smithy models but does not create a JAR.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/failure-cases/invalid-projection/build.gradle.kts
+++ b/examples/failure-cases/invalid-projection/build.gradle.kts
@@ -1,7 +1,6 @@
 // This example attempts to use an invalid projection. The build will fail.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
+++ b/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
@@ -4,7 +4,6 @@
 // plugin validates the JAR with Smithy model discovery.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/failure-cases/syntax-error/build.gradle.kts
+++ b/examples/failure-cases/syntax-error/build.gradle.kts
@@ -1,7 +1,6 @@
 // This example fails to build due to a syntax error.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/multiple-sources/build.gradle.kts
+++ b/examples/multiple-sources/build.gradle.kts
@@ -4,7 +4,6 @@
 // - src/main/resources/META-INF/smithy
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/projection/build.gradle.kts
+++ b/examples/projection/build.gradle.kts
@@ -1,7 +1,6 @@
 // This example places a projected version of the model into the JAR.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/projects-with-tags/build.gradle.kts
+++ b/examples/projects-with-tags/build.gradle.kts
@@ -1,7 +1,6 @@
 // This example places a projected version of the model into the JAR.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/examples/source-projection/build.gradle.kts
+++ b/examples/source-projection/build.gradle.kts
@@ -1,7 +1,6 @@
 // This example builds the model and places it in the JAR.
 
 plugins {
-    java
     id("software.amazon.smithy").version("0.3.0")
 }
 

--- a/src/main/java/software/amazon/smithy/gradle/SmithyPlugin.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyPlugin.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import software.amazon.smithy.gradle.tasks.SmithyBuildJar;
@@ -43,6 +44,7 @@ public final class SmithyPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getPluginManager().apply(JavaPlugin.class);
         project.getPluginManager().withPlugin("java", javaPlugin -> {
             appliedPlugin = true;
             SmithyExtension extension = project.getExtensions().create("smithy", SmithyExtension.class);


### PR DESCRIPTION
This commit automatically applies the java plugin and removes the need
for Smithy model projects to apply the java plugin.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
