### PR TITLE
Remove the disabling of more in-depth JIT

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -23,7 +23,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSetContainer;
 import software.amazon.smithy.cli.SmithyCli;
-import software.amazon.smithy.utils.ListUtils;
 
 /**
  * General utility methods used throughout the plugin.
@@ -156,7 +155,6 @@ public final class SmithyUtils {
             t.setArgs(arguments);
             t.setClasspath(resolveClasspath);
             t.setMain(SmithyCli.class.getCanonicalName());
-            t.setJvmArgs(ListUtils.of("-XX:TieredStopAtLevel=2"));
         });
     }
 


### PR DESCRIPTION
The Gradle plugin previously optimized for fast startup, but this came
at the expense of more demanding long-running tasks like building large
models. This change disables capping the maximum JIT level so that more
optimizations can be made. This resulted in a reduction from ~17secs to
~11 seconds for large model builds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
