### PR TITLE
Run CLI in thread by default

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/SmithyExtension.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyExtension.java
@@ -33,6 +33,7 @@ public class SmithyExtension {
     private Set<String> tags = new LinkedHashSet<>();
     private boolean allowUnknownTraits;
     private File outputDirectory;
+    private boolean fork;
 
     /**
      * Gets the projection name in use by the extension.
@@ -148,6 +149,29 @@ public class SmithyExtension {
      */
     public void setAllowUnknownTraits(boolean allowUnknownTraits) {
         this.allowUnknownTraits = allowUnknownTraits;
+    }
+
+    /**
+     * Gets whether or not to fork when running the Smithy CLI.
+     *
+     * <p>By default, the CLI is run in the same process as Gradle,
+     * but inside of a thread with a custom class loader. This should
+     * work in most cases, but there is an option to run inside of a
+     * process if necessary.
+     *
+     * @return Returns true if the CLI should fork.
+     */
+    public boolean getFork() {
+        return fork;
+    }
+
+    /**
+     * Sets whether or not to fork when running the Smithy CLI.
+     *
+     * @param fork Set to true to fork when running the Smithy CLI.
+     */
+    public void setFork(boolean fork) {
+        this.fork = fork;
     }
 
     /**

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
@@ -230,7 +230,7 @@ public class SmithyBuildJar extends BaseSmithyTask {
 
         BuildParameterBuilder.Result result = builder.build();
         Object[] jars = result.classpath.split(":");
-        SmithyUtils.executeCliProcess(getProject(), result.args, getProject().files(jars));
+        SmithyUtils.executeCli(getProject(), result.args, getProject().files(jars));
 
         // Copy generated files where they're needed and register source sets.
         try {

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyCliTask.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyCliTask.java
@@ -135,6 +135,6 @@ abstract class SmithyCliTask extends BaseSmithyTask {
             models.forEach(file -> args.add(file.getAbsolutePath()));
         });
 
-        SmithyUtils.executeCliProcess(getProject(), args, cliClasspath);
+        SmithyUtils.executeCli(getProject(), args, cliClasspath);
     }
 }


### PR DESCRIPTION
Rather than always run in a process, this change allows the Smithy CLI
to be run in a thread using a custom class loader. This will probably
work in every case, but just in case, I added an option to force the CLI
to run in a separate process using the "fork" option.

On my machine, this change had the effect of shaving on ~1 second of time to
run a normal build. You also get much better stack traces when something
goes wrong since it's not run in a different process.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
