### PR TITLE
Fix build graph issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,9 @@ group = "software.amazon.smithy"
 version = "0.4.2"
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
-    implementation("software.amazon.smithy:smithy-build:0.9.6")
-    implementation("software.amazon.smithy:smithy-cli:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-build:0.9.7")
+    implementation("software.amazon.smithy:smithy-cli:0.9.7")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.0")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")

--- a/examples/adds-tags/build.gradle.kts
+++ b/examples/adds-tags/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/disable-jar/build.gradle.kts
+++ b/examples/disable-jar/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 }
 
 tasks["jar"].enabled = false

--- a/examples/failure-cases/invalid-projection/build.gradle.kts
+++ b/examples/failure-cases/invalid-projection/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
+++ b/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         // This dependency is required to build the model.
-        classpath("software.amazon.smithy:smithy-aws-traits:0.9.6")
+        classpath("software.amazon.smithy:smithy-aws-traits:0.9.7")
     }
 }
 
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 
     // This dependency is used in the projected model, so it's required here too.
     // This should fail to build since this is missing.
-    //implementation("software.amazon.smithy:smithy-aws-traits:0.9.6")
+    //implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/failure-cases/syntax-error/build.gradle.kts
+++ b/examples/failure-cases/syntax-error/build.gradle.kts
@@ -10,5 +10,5 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 }

--- a/examples/multi-project/build.gradle.kts
+++ b/examples/multi-project/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    `java-library`
+}
+
+allprojects {
+    group = "software.amazon.smithy.it"
+    version = "999.999.999"
+}
+
+tasks["jar"].enabled = false
+
+subprojects {
+    apply(plugin = "java-library")
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/examples/multi-project/consumer/build.gradle.kts
+++ b/examples/multi-project/consumer/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("software.amazon.smithy").version("0.4.2")
+}
+
+dependencies {
+    implementation(project(":producer1"))
+    implementation(project(":producer2"))
+}

--- a/examples/multi-project/consumer/model/main.smithy
+++ b/examples/multi-project/consumer/model/main.smithy
@@ -1,0 +1,8 @@
+namespace smithy.consumer
+
+use smithy.producer#producer1
+use smithy.producer#producer2
+
+@producer1
+@producer2
+structure Foo {}

--- a/examples/multi-project/gradle.properties
+++ b/examples/multi-project/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true

--- a/examples/multi-project/producer1/build.gradle.kts
+++ b/examples/multi-project/producer1/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api("software.amazon.smithy:smithy-model:0.9.7")
+}

--- a/examples/multi-project/producer1/src/main/java/software/amazon/smithy/producer1/Producer1Trait.java
+++ b/examples/multi-project/producer1/src/main/java/software/amazon/smithy/producer1/Producer1Trait.java
@@ -1,0 +1,23 @@
+package software.amazon.smithy.producer1;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.BooleanTrait;
+
+public final class Producer1Trait extends BooleanTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.producer#producer1");
+
+    public Producer1Trait(SourceLocation sourceLocation) {
+        super(ID, sourceLocation);
+    }
+
+    public Producer1Trait() {
+        this(SourceLocation.NONE);
+    }
+
+    public static final class Provider extends BooleanTrait.Provider<Producer1Trait> {
+        public Provider() {
+            super(ID, Producer1Trait::new);
+        }
+    }
+}

--- a/examples/multi-project/producer1/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/examples/multi-project/producer1/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -1,0 +1,1 @@
+software.amazon.smithy.producer1.Producer1Trait$Provider

--- a/examples/multi-project/producer1/src/main/resources/META-INF/smithy/main.smithy
+++ b/examples/multi-project/producer1/src/main/resources/META-INF/smithy/main.smithy
@@ -1,0 +1,4 @@
+namespace smithy.producer
+
+@trait(selector: "*")
+structure producer1 {}

--- a/examples/multi-project/producer1/src/main/resources/META-INF/smithy/manifest
+++ b/examples/multi-project/producer1/src/main/resources/META-INF/smithy/manifest
@@ -1,0 +1,1 @@
+main.smithy

--- a/examples/multi-project/producer2/build.gradle.kts
+++ b/examples/multi-project/producer2/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api("software.amazon.smithy:smithy-model:0.9.7")
+}

--- a/examples/multi-project/producer2/src/main/java/software/amazon/smithy/producer2/Producer2Trait.java
+++ b/examples/multi-project/producer2/src/main/java/software/amazon/smithy/producer2/Producer2Trait.java
@@ -1,0 +1,23 @@
+package software.amazon.smithy.producer2;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.BooleanTrait;
+
+public final class Producer2Trait extends BooleanTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.producer#producer2");
+
+    public Producer2Trait(SourceLocation sourceLocation) {
+        super(ID, sourceLocation);
+    }
+
+    public Producer2Trait() {
+        this(SourceLocation.NONE);
+    }
+
+    public static final class Provider extends BooleanTrait.Provider<Producer2Trait> {
+        public Provider() {
+            super(ID, Producer2Trait::new);
+        }
+    }
+}

--- a/examples/multi-project/producer2/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/examples/multi-project/producer2/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -1,0 +1,1 @@
+software.amazon.smithy.producer2.Producer2Trait$Provider

--- a/examples/multi-project/producer2/src/main/resources/META-INF/smithy/main.smithy
+++ b/examples/multi-project/producer2/src/main/resources/META-INF/smithy/main.smithy
@@ -1,0 +1,4 @@
+namespace smithy.producer
+
+@trait(selector: "*")
+structure producer2 {}

--- a/examples/multi-project/producer2/src/main/resources/META-INF/smithy/manifest
+++ b/examples/multi-project/producer2/src/main/resources/META-INF/smithy/manifest
@@ -1,0 +1,1 @@
+main.smithy

--- a/examples/multi-project/settings.gradle.kts
+++ b/examples/multi-project/settings.gradle.kts
@@ -1,0 +1,13 @@
+rootProject.name = "multi-project"
+
+include(":producer1")
+include(":producer2")
+include(":consumer")
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}

--- a/examples/multiple-sources/build.gradle.kts
+++ b/examples/multiple-sources/build.gradle.kts
@@ -13,5 +13,5 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 }

--- a/examples/projection/build.gradle.kts
+++ b/examples/projection/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         // This dependency is required to build the model.
-        classpath("software.amazon.smithy:smithy-aws-traits:0.9.6")
+        classpath("software.amazon.smithy:smithy-aws-traits:0.9.7")
     }
 }
 
@@ -20,10 +20,10 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 
     // This dependency is used in the projected model, so it's requird here too.
-    implementation("software.amazon.smithy:smithy-aws-traits:0.9.6")
+    implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/projects-with-tags/build.gradle.kts
+++ b/examples/projects-with-tags/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/smithy-build-task/build.gradle.kts
+++ b/examples/smithy-build-task/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
 }
 
 tasks["jar"].enabled = false

--- a/examples/source-projection/build.gradle.kts
+++ b/examples/source-projection/build.gradle.kts
@@ -10,8 +10,8 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.6")
-    implementation("software.amazon.smithy:smithy-aws-traits:0.9.6")
+    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/src/it/java/software/amazon/smithy/gradle/Utils.java
+++ b/src/it/java/software/amazon/smithy/gradle/Utils.java
@@ -32,6 +32,7 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Assertions;
 
@@ -99,7 +100,8 @@ public final class Utils {
     }
 
     public static void assertSmithyBuildDidNotRun(BuildResult result) {
-        Assertions.assertTrue(result.task(":smithyBuildJar") == null);
+        BuildTask task = result.task(":smithyBuildJar");
+        Assertions.assertTrue(task == null || task.getOutcome() == TaskOutcome.SKIPPED);
     }
 
     public static void assertValidationRan(BuildResult result) {

--- a/src/main/java/software/amazon/smithy/gradle/SmithyPlugin.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyPlugin.java
@@ -37,7 +37,7 @@ import software.amazon.smithy.utils.ListUtils;
  */
 public final class SmithyPlugin implements Plugin<Project> {
 
-    private static final String DEFAULT_CLI_VERSION = "0.9.6";
+    private static final String DEFAULT_CLI_VERSION = "0.9.7";
     private static final List<String> SOURCE_DIRS = ListUtils.of(
             "model", "src/$name/smithy", "src/$name/resources/META-INF/smithy");
     private static final Logger LOGGER = Logger.getLogger(SmithyPlugin.class.getName());
@@ -49,28 +49,21 @@ public final class SmithyPlugin implements Plugin<Project> {
 
         // Register the Smithy extension so that tasks can be configured.
         project.getExtensions().create("smithy", SmithyExtension.class);
+        addCliDependencies(project);
+        registerSourceSets(project);
 
         // Register the "smithyBuildJar" task. It's configured once the extension is available.
         TaskProvider<SmithyBuildJar> provider = project.getTasks().register("smithyBuildJar", SmithyBuildJar.class);
 
-        // Can't read from the "smithy" extension until the "afterEvaluate" step.
-        project.afterEvaluate(p -> {
-            registerSourceSets(project);
-            addCliDependencies(project);
-            registerSmithyBuildTask(provider.get(), project);
+        // This is lazy task configuration that allows the SmithyBuildJar
+        // task to be configured and wired into the task graph, but only
+        // if it's actually needed, and (presumably) it's deferred until
+        // after user Gradle files can configure the task.
+        provider.configure(task -> {
+            task.dependsOn("compileJava");
         });
-    }
 
-    private void registerSmithyBuildTask(SmithyBuildJar buildTask, Project project) {
-        if (!buildTask.isEnabled()) {
-            LOGGER.info("Smithy build task is not enabled");
-        } else if (!project.getTasks().getByName("jar").getEnabled()) {
-            LOGGER.info("Smithy build task is enabled. Running Smithy before 'assemble'");
-            project.getTasks().getByName("assemble").dependsOn(buildTask);
-        } else {
-            LOGGER.info("Smithy build task is enabled. Running Smithy before 'processResources'");
-            project.getTasks().getByName("processResources").dependsOn(buildTask);
-        }
+        project.getTasks().getByName("processResources").dependsOn(provider);
     }
 
     /**

--- a/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -211,6 +211,7 @@ public final class SmithyUtils {
                     cliClass.getDeclaredMethod("classLoader", ClassLoader.class).invoke(cli, classLoader);
                     cliClass.getDeclaredMethod("run", List.class).invoke(cli, arguments);
                 } catch (ReflectiveOperationException e) {
+                    LOGGER.severe("Reflection error: " + e);
                     throw new RuntimeException(e);
                 }
             });
@@ -222,13 +223,14 @@ public final class SmithyUtils {
             thread.start();
             thread.join();
             if (handler.e != null) {
+                LOGGER.severe("Enception handler: " + handler.e);
                 throw handler.e;
             }
 
             classLoader.close();
 
         } catch (Throwable e) {
-            throw new GradleException("Error running Smithy CLI (thread): " + e.getMessage(), e);
+            throw new GradleException("Error running Smithy CLI (thread): " + e, e);
         }
     }
 


### PR DESCRIPTION
Smithy needs to run after compileJava so that dependencies in the same
project are built first. It also needs to run before processResources so
that artifacts created by Smithy are considered part of the generated
JAR.

This has been tested using the integration tests in this package as well
as using the awslabs/smithy repo with various states (clean build and
cleaning individual projects).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
