### PR TITLE
Make fixes to Gradle dependencies and output

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.gradle;
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -23,13 +24,16 @@ import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
+import java.util.function.Consumer;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSetContainer;
+import software.amazon.smithy.cli.Cli;
 import software.amazon.smithy.cli.SmithyCli;
 
 /**
@@ -41,9 +45,18 @@ public final class SmithyUtils {
     private static final String MAIN_SOURCE_SET = "main";
     private static final String SMITHY_SOURCE_SET_EXTENSION = "smithy";
     private static final String SOURCE_SETS_PROPERTY = "sourceSets";
-    private static final Logger LOGGER = Logger.getLogger(SmithyUtils.class.getName());
 
     private SmithyUtils() {}
+
+    /**
+     * Gets the {@code SmithyExtension} extension of a {@code Project}.
+     *
+     * @param project Project to query.
+     * @return Returns the extension.
+     */
+    public static SmithyExtension getSmithyExtension(Project project) {
+        return project.getExtensions().getByType(SmithyExtension.class);
+    }
 
     /**
      * Gets the path to a projection plugins output.
@@ -81,7 +94,6 @@ public final class SmithyUtils {
         return getSmithySourceDirectory(project, MAIN_SOURCE_SET);
     }
 
-    @SuppressWarnings("unchecked")
     private static SourceDirectorySet getSmithySourceDirectory(Project project, String name) {
         // Grab a list of all the files and directories to mark as sources.
         return (SourceDirectorySet) project.getConvention()
@@ -98,7 +110,7 @@ public final class SmithyUtils {
      * @param project Project to inspect.
      * @return Returns the Smithy CLI classpath used to run the CLI.
      */
-    public static FileCollection getSmithyCliClasspath(Project project) {
+    private static Configuration getSmithyCliClasspath(Project project) {
         return getClasspath(project, "smithyCli");
     }
 
@@ -109,7 +121,7 @@ public final class SmithyUtils {
      * @param configurationName Name of the classpath to retrieve.
      * @return Returns the classpath.
      */
-    public static FileCollection getClasspath(Project project, String configurationName) {
+    public static Configuration getClasspath(Project project, String configurationName) {
         return project.getConfigurations().getByName(configurationName);
     }
 
@@ -119,7 +131,7 @@ public final class SmithyUtils {
      * @param project Project to inspect.
      * @return Returns the classpath.
      */
-    public static FileCollection getBuildscriptClasspath(Project project) {
+    public static Configuration getBuildscriptClasspath(Project project) {
         return project.getBuildscript().getConfigurations().getByName("classpath");
     }
 
@@ -131,8 +143,13 @@ public final class SmithyUtils {
      * @return Returns the classpath.
      */
     public static File getSmithyResourceTempDir(Project project) {
-        Path metaInf = project.getBuildDir().toPath().resolve("tmp").resolve("smithy-inf");
-        return metaInf.resolve("META-INF").resolve("smithy").toFile();
+        return project.getBuildDir()
+                .toPath()
+                .resolve("tmp")
+                .resolve("smithy-inf")
+                .resolve("META-INF")
+                .resolve("smithy")
+                .toFile();
     }
 
     /**
@@ -141,12 +158,31 @@ public final class SmithyUtils {
      * @param project Project to inspect.
      * @return Returns the default output directory.
      */
-    public static File getProjectionOutputDir(Project project) {
-        return project.getProjectDir().toPath()
+    private static File getProjectionOutputDir(Project project) {
+        return project.getProjectDir()
+                .toPath()
                 .resolve("build")
                 .resolve(SMITHY_PROJECTIONS)
                 .resolve(project.getName())
                 .toFile();
+    }
+
+    /**
+     * Resolves the appropriate output directory for Smithy artifacts.
+     *
+     * @param currentTaskValue The possibly null value currently set on a task.
+     * @param project The project to query.
+     * @return Returns the resolved directory.
+     */
+    public static File resolveOutputDirectory(File currentTaskValue, Project project) {
+        if (currentTaskValue != null) {
+            return currentTaskValue;
+        }
+
+        SmithyExtension extension = getSmithyExtension(project);
+        return extension.getOutputDirectory() != null
+               ? extension.getOutputDirectory()
+               : SmithyUtils.getProjectionOutputDir(project);
     }
 
     /**
@@ -157,27 +193,42 @@ public final class SmithyUtils {
      * @param classpath Classpath to use when running the CLI. Uses buildScript when not defined.
      */
     public static void executeCli(Project project, List<String> arguments, FileCollection classpath) {
-        FileCollection resolveClasspath = resolveCliClasspath(project, classpath);
-        boolean fork = project.getExtensions().getByType(SmithyExtension.class).getFork();
-        LOGGER.fine(String.format("Executing Smithy CLI in a %s: %s; using classpath %s",
-                                  fork ? "process" : "thread",
-                                  String.join(" ", arguments),
-                                  resolveClasspath.getAsPath()));
+        FileCollection resolvedClasspath = resolveCliClasspath(project, classpath);
+        boolean fork = getSmithyExtension(project).getFork();
+        project.getLogger().info("Executing Smithy CLI in a {}: {}; using classpath {}",
+                                 fork ? "process" : "thread",
+                                 String.join(" ", arguments),
+                                 resolvedClasspath.getAsPath());
         if (fork) {
-            executeCliProcess(project, arguments, resolveClasspath);
+            executeCliProcess(project, arguments, resolvedClasspath);
         } else {
-            executeCliThread(arguments, resolveClasspath);
+            executeCliThread(project, arguments, resolvedClasspath);
         }
     }
 
-    public static File resolveOutputDirectory(File setOnTask, SmithyExtension extension, Project project) {
-        if (setOnTask != null) {
-            return setOnTask;
-        } else if (extension.getOutputDirectory() != null) {
-            return extension.getOutputDirectory();
-        } else {
-            return SmithyUtils.getProjectionOutputDir(project);
+    private static FileCollection resolveCliClasspath(Project project, FileCollection cliClasspath) {
+        if (cliClasspath == null) {
+            FileCollection buildScriptCp = SmithyUtils.getBuildscriptClasspath(project);
+            project.getLogger().info("Smithy CLI classpath is null, so using buildscript: {}", buildScriptCp);
+            return resolveCliClasspath(project, buildScriptCp);
         }
+
+        // Add the CLI classpath if it's missing from the given classpath.
+        if (!cliClasspath.getAsPath().contains("smithy-cli")) {
+            FileCollection defaultCliCp = SmithyUtils.getSmithyCliClasspath(project);
+            project.getLogger().info("Adding CLI classpath to command: {}", defaultCliCp.getAsPath());
+            cliClasspath = cliClasspath.plus(defaultCliCp);
+        } else {
+            project.getLogger().info("Smithy CLI classpath already has the CLI in it");
+        }
+
+        for (File f : cliClasspath) {
+            if (!f.exists()) {
+                project.getLogger().error("CLI classpath JAR does not exist: {}", f);
+            }
+        }
+
+        return cliClasspath;
     }
 
     private static void executeCliProcess(Project project, List<String> arguments, FileCollection classpath) {
@@ -189,29 +240,40 @@ public final class SmithyUtils {
     }
 
     @SuppressWarnings("unchecked")
-    private static void executeCliThread(List<String> arguments, FileCollection classpath) {
-        try {
-            // Create a custom class loader to run within the context of.
-            Set<File> files = classpath.getFiles();
-            URL[] paths = new URL[files.size()];
-            int i = 0;
-            for (File file : files) {
+    private static void executeCliThread(Project project, List<String> arguments, FileCollection classpath) {
+        // Create a custom class loader to run within the context of.
+        Set<File> files = classpath.getFiles();
+        URL[] paths = new URL[files.size()];
+        int i = 0;
+
+        for (File file : files) {
+            try {
                 paths[i++] = file.toURI().toURL();
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
             }
-            // Need to run this in a doPriveleged to pass SpotBugs.
-            URLClassLoader classLoader = AccessController.doPrivileged(
-                    (PrivilegedExceptionAction<URLClassLoader>) () -> new URLClassLoader(paths));
+        }
+
+        Logger logger = project.getLogger();
+
+        // Need to run this in a doPrivileged to pass SpotBugs.
+        try (URLClassLoader classLoader = AccessController.doPrivileged(
+                (PrivilegedExceptionAction<URLClassLoader>) () -> new URLClassLoader(paths))) {
 
             // Reflection is used to make calls on the loaded SmithyCli object.
-            String cliName = SmithyCli.class.getCanonicalName();
+            String smithyCliName = SmithyCli.class.getCanonicalName();
+            String cliName = Cli.class.getCanonicalName();
+
             Thread thread = new Thread(() -> {
                 try {
                     Class cliClass = classLoader.loadClass(cliName);
-                    Object cli = cliClass.getDeclaredMethod("create").invoke(null);
-                    cliClass.getDeclaredMethod("classLoader", ClassLoader.class).invoke(cli, classLoader);
-                    cliClass.getDeclaredMethod("run", List.class).invoke(cli, arguments);
+                    Class smithyCliClass = classLoader.loadClass(smithyCliName);
+                    Object cli = smithyCliClass.getDeclaredMethod("create").invoke(null);
+                    smithyCliClass.getDeclaredMethod("classLoader", ClassLoader.class).invoke(cli, classLoader);
+                    overrideCliStdout(cliClass, logger);
+                    smithyCliClass.getDeclaredMethod("run", List.class).invoke(cli, arguments);
                 } catch (ReflectiveOperationException e) {
-                    LOGGER.severe("Reflection error: " + e);
+                    logger.info("Error executing Smithy CLI (ReflectiveOperationException)", e);
                     throw new RuntimeException(e);
                 }
             });
@@ -222,15 +284,57 @@ public final class SmithyUtils {
             thread.setUncaughtExceptionHandler(handler);
             thread.start();
             thread.join();
+
             if (handler.e != null) {
-                LOGGER.severe("Enception handler: " + handler.e);
+                logger.info("Error executing Smithy CLI (thread handler)", handler.e);
                 throw handler.e;
             }
 
-            classLoader.close();
-
         } catch (Throwable e) {
-            throw new GradleException("Error running Smithy CLI (thread): " + e, e);
+            // Find the originating exception message.
+            String message;
+            Throwable current = e;
+            do {
+                message = current.getMessage();
+                current = current.getCause();
+            } while (current != null);
+            logger.error(message);
+            throw new GradleException(message, e);
+        }
+    }
+
+    // ** This is a hack! **
+    //
+    // Gradle attempts to intercept writing to System.out and System.err by
+    // sending each write to Gradle's logging system. However, when paired with
+    // org.gradle.parallel=true, Gradle sometimes writes stdout and sometimes
+    // it doesn't. This implies that their logging implementation and the way
+    // they intercept stderr and stdout is not thread-safe. Smithy's build
+    // process is run inside of a thread so that we can use the same JVM process
+    // but completely change the thread's ClassLoader using the appropriate
+    // dependencies (e.g., runtime vs buildscript). Smithy then further
+    // utilized thread pools when building projections and plugins. Somewhere
+    // along the way, thread-safety is lost and the Smithy CLI's writing to
+    // stdout is lost.
+    //
+    // This hack required that a new method was introduced to the Smithy CLI
+    // that uses a Consumer<String> to write a line of text. By default, the
+    // CLI writes to System.out.println and System.err.println, but this change
+    // cause the Smithy CLI to write warning messages to the provided Logger.
+    // Why warning? Changing the logging level of a task also appears to be
+    // unreliable. Maybe there's a way to do it so that we can log using info
+    // and then change the log level to info, but I couldn't find it.
+    @SuppressWarnings("unchecked")
+    private static void overrideCliStdout(Class cliClass, Logger logger) {
+        try {
+            cliClass.getDeclaredMethod("setStdout", Consumer.class).invoke(null, new Consumer<String>() {
+                @Override
+                public void accept(String s) {
+                    logger.warn(s);
+                }
+            });
+        } catch (ReflectiveOperationException e) {
+            logger.warn("Found an old version of Smithy CLI that does not support Cli#setStdout");
         }
     }
 
@@ -241,19 +345,5 @@ public final class SmithyUtils {
         public void uncaughtException(Thread t, Throwable e) {
             this.e = e;
         }
-    }
-
-    private static FileCollection resolveCliClasspath(Project project, FileCollection cliClasspath) {
-        if (cliClasspath == null) {
-            cliClasspath = SmithyUtils.getBuildscriptClasspath(project);
-        }
-
-        // Add the CLI classpath if it's missing from the given classpath.
-        if (!cliClasspath.getAsPath().contains("smithy-cli")) {
-            LOGGER.fine("Adding CLI classpath to command");
-            cliClasspath = cliClasspath.plus(SmithyUtils.getSmithyCliClasspath(project));
-        }
-
-        return cliClasspath;
     }
 }

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuild.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuild.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.gradle.tasks;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
@@ -36,8 +35,6 @@ import software.amazon.smithy.gradle.SmithyUtils;
  */
 public class SmithyBuild extends SmithyCliTask {
 
-    private static final Logger LOGGER = Logger.getLogger(SmithyBuild.class.getName());
-
     private FileCollection smithyBuildConfigs;
     private File outputDirectory;
 
@@ -48,8 +45,7 @@ public class SmithyBuild extends SmithyCliTask {
      */
     @OutputDirectory
     public File getOutputDirectory() {
-        SmithyExtension extension = getProject().getExtensions().getByType(SmithyExtension.class);
-        return SmithyUtils.resolveOutputDirectory(outputDirectory, extension, getProject());
+        return SmithyUtils.resolveOutputDirectory(outputDirectory, getProject());
     }
 
     /**
@@ -90,15 +86,12 @@ public class SmithyBuild extends SmithyCliTask {
 
     @TaskAction
     public void execute() {
-        super.execute();
-
         // Configure the task from the extension if things aren't already setup.
-        SmithyExtension extension = getProject().getExtensions().getByType(SmithyExtension.class);
+        SmithyExtension extension = SmithyUtils.getSmithyExtension(getProject());
 
         if (smithyBuildConfigs == null) {
-            LOGGER.finer(() -> String.format(
-                    "Setting smithyBuildConfigs of %s to %s from SmithyExtension",
-                    getClass().getName(), extension.getSmithyBuildConfigs()));
+            getLogger().debug("Setting smithyBuildConfigs of {} to {} from SmithyExtension",
+                              getClass().getName(), extension.getSmithyBuildConfigs());
             setSmithyBuildConfigs(extension.getSmithyBuildConfigs());
         }
 
@@ -109,7 +102,7 @@ public class SmithyBuild extends SmithyCliTask {
 
         getSmithyBuildConfigs().forEach(file -> {
             if (file.exists()) {
-                LOGGER.finest(() -> "Adding configuration file to CLI: " + file);
+                getLogger().debug("Adding configuration file to CLI: {}", file);
                 customArgs.add("--config");
                 customArgs.add(file.getAbsolutePath());
             }

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyCliTask.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyCliTask.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.gradle.tasks;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -29,9 +28,6 @@ import software.amazon.smithy.gradle.SmithyUtils;
  * (that is, tasks that are meant to be run ad-hoc).
  */
 abstract class SmithyCliTask extends BaseSmithyTask {
-
-    private static final Logger LOGGER = Logger.getLogger(SmithyCliTask.class.getName());
-
     private FileCollection classpath;
     private FileCollection modelDiscoveryClasspath;
     private boolean disableModelDiscovery;
@@ -190,11 +186,11 @@ abstract class SmithyCliTask extends BaseSmithyTask {
             if (getAddCompileClasspath()) {
                 cliClasspath = cliClasspath.plus(SmithyUtils.getClasspath(getProject(), COMPILE_CLASSPATH));
             }
-            LOGGER.fine(String.format(
-                    "Configuring classpath: runtime: %s; compile: %s; buildscript: %s; updated from %s to %s",
+            getLogger().debug(
+                    "Configuring classpath: runtime: {}; compile: {}; buildscript: {}; updated from {} to {}",
                     addRuntimeClasspath, addCompileClasspath, addBuildScriptClasspath,
                     originalCliClasspath == null ? "null" : originalCliClasspath.getAsPath(),
-                    cliClasspath.getAsPath()));
+                    cliClasspath.getAsPath());
         }
 
         List<String> args = new ArrayList<>();
@@ -217,10 +213,10 @@ abstract class SmithyCliTask extends BaseSmithyTask {
             args.add("--");
             getModels().forEach(file -> {
                 if (file.exists()) {
-                    LOGGER.finest(() -> "Adding Smithy model file to CLI: " + file);
+                    getLogger().debug("Adding Smithy model file to CLI: {}", file);
                     args.add(file.getAbsolutePath());
                 } else {
-                    LOGGER.severe("Skipping Smithy model file because it does not exist: " + file);
+                    getLogger().error("Skipping Smithy model file because it does not exist: {}", file);
                 }
             });
         }

--- a/src/main/java/software/amazon/smithy/gradle/tasks/Validate.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/Validate.java
@@ -34,7 +34,7 @@ public class Validate extends SmithyCliTask {
 
     @TaskAction
     public void execute() {
-        super.execute();
+        writeHeading("Running smithy validate");
         executeCliProcess("validate", ListUtils.of(), getClasspath(), getModelDiscoveryClasspath());
     }
 }


### PR DESCRIPTION
This commits makes many changes to the Gradle plugin to address the
following issues:

1. Fixes writing to stderr and stdout from Smithy CLI. Writing to
   stdout and stderr was really inconsistent in whether or not
   it's able to reroute writing to stdout to it's logging machinery.
   This might be because Smithy makes use of threads within a task,
   not sure. To workaround this, I've updating the Smithy CLI to
   instead of writing directly to stdout, invokes a customizable
   Consumer<String>. The Gradle plugin changes this to instead
   directly log a warning message. This works every time.
2. Fixes build order and dependencies of building the Smithy model
   and validating the model. There was a lot that changed here,
   including how tasks are created, referenced, and ordered.
3. The Gradle plugin now uses the Gradle logger directly rather than
   JUL. This results in more uniform log messages and doesn't interfere
   with the intercepting of stderr/stdout.
4. The plugin now detects when using the Gradle plugin in the main
   Smithy repo. When detected, the plugin ensures that a direct
   dependency is made on smithy-cli so that project dependencies are
   used rather than whatever's in Maven.
5. Various simplifications and logging improvements.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
