### PR TITLE
Version 0.5.0 for Smithy 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ The following example configures a project to use the Smithy Gradle plugin:
 
 ```kotlin
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 ```
 
 
 ## Documentation
 
-See https://awslabs.github.io/smithy/guides/building-models/gradle-plugin.html
+See https://awslabs.github.io/smithy/1.0/guides/building-models/gradle-plugin.html
 
 
 ## License

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,12 +23,12 @@ plugins {
 }
 
 group = "software.amazon.smithy"
-version = "0.4.3"
+version = "0.5.0"
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
-    implementation("software.amazon.smithy:smithy-build:0.9.7")
-    implementation("software.amazon.smithy:smithy-cli:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
+    implementation("software.amazon.smithy:smithy-build:1.0.0")
+    implementation("software.amazon.smithy:smithy-cli:1.0.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.0")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")

--- a/examples/adds-tags/build.gradle.kts
+++ b/examples/adds-tags/build.gradle.kts
@@ -1,7 +1,7 @@
 // This examples adds a Smithy tag to the built JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 group = "software.amazon.smithy"
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/disable-jar/build.gradle.kts
+++ b/examples/disable-jar/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example builds Smithy models but does not create a JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 repositories {
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 }
 
 tasks["jar"].enabled = false

--- a/examples/failure-cases/invalid-projection/build.gradle.kts
+++ b/examples/failure-cases/invalid-projection/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example attempts to use an invalid projection. The build will fail.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 repositories {
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
+++ b/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
@@ -4,7 +4,7 @@
 // plugin validates the JAR with Smithy model discovery.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 buildscript {
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         // This dependency is required to build the model.
-        classpath("software.amazon.smithy:smithy-aws-traits:0.9.7")
+        classpath("software.amazon.smithy:smithy-aws-traits:1.0.0")
     }
 }
 
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 
     // This dependency is used in the projected model, so it's required here too.
     // This should fail to build since this is missing.
-    //implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
+    //implementation("software.amazon.smithy:smithy-aws-traits:1.0.0")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/failure-cases/missing-runtime-dependency/model/main.smithy
+++ b/examples/failure-cases/missing-runtime-dependency/model/main.smithy
@@ -4,5 +4,5 @@ structure Baz {
   foo: String
 }
 
-@aws.api#unsignedPayload
-operation Foo()
+@aws.auth#unsignedPayload
+operation Foo {}

--- a/examples/failure-cases/syntax-error/build.gradle.kts
+++ b/examples/failure-cases/syntax-error/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example fails to build due to a syntax error.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 repositories {
@@ -10,5 +10,5 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 }

--- a/examples/multi-project/consumer/build.gradle.kts
+++ b/examples/multi-project/consumer/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 dependencies {

--- a/examples/multi-project/producer1/build.gradle.kts
+++ b/examples/multi-project/producer1/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-model:0.9.7")
+    api("software.amazon.smithy:smithy-model:1.0.0")
 }

--- a/examples/multi-project/producer2/build.gradle.kts
+++ b/examples/multi-project/producer2/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-model:0.9.7")
+    api("software.amazon.smithy:smithy-model:1.0.0")
 }

--- a/examples/multiple-sources/build.gradle.kts
+++ b/examples/multiple-sources/build.gradle.kts
@@ -4,7 +4,7 @@
 // - src/main/resources/META-INF/smithy
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 repositories {
@@ -13,5 +13,5 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 }

--- a/examples/projection/build.gradle.kts
+++ b/examples/projection/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example places a projected version of the model into the JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 buildscript {
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         // This dependency is required to build the model.
-        classpath("software.amazon.smithy:smithy-aws-traits:0.9.7")
+        classpath("software.amazon.smithy:smithy-aws-traits:1.0.0")
     }
 }
 
@@ -20,10 +20,10 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 
     // This dependency is used in the projected model, so it's requird here too.
-    implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
+    implementation("software.amazon.smithy:smithy-aws-traits:1.0.0")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/projection/model/main.smithy
+++ b/examples/projection/model/main.smithy
@@ -4,5 +4,5 @@ structure Baz {
   foo: String
 }
 
-@aws.api#unsignedPayload
-operation Foo()
+@aws.auth#unsignedPayload
+operation Foo {}

--- a/examples/projects-with-tags/build.gradle.kts
+++ b/examples/projects-with-tags/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example places a projected version of the model into the JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 buildscript {
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/smithy-build-task/build.gradle.kts
+++ b/examples/smithy-build-task/build.gradle.kts
@@ -6,7 +6,7 @@ import software.amazon.smithy.gradle.tasks.SmithyBuild
 // and the classpath used when building.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 repositories {
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
 }
 
 tasks["jar"].enabled = false

--- a/examples/source-projection/build.gradle.kts
+++ b/examples/source-projection/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example builds the model and places it in the JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.0")
 }
 
 repositories {
@@ -10,8 +10,8 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:0.9.7")
-    implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
+    implementation("software.amazon.smithy:smithy-model:1.0.0")
+    implementation("software.amazon.smithy:smithy-aws-traits:1.0.0")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/source-projection/model/main.smithy
+++ b/examples/source-projection/model/main.smithy
@@ -4,5 +4,5 @@ structure Baz {
   foo: String
 }
 
-@aws.api#unsignedPayload
-operation Foo()
+@aws.auth#unsignedPayload
+operation Foo {}

--- a/src/it/java/software/amazon/smithy/gradle/ProjectsWithTagsTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/ProjectsWithTagsTest.java
@@ -43,9 +43,9 @@ public class ProjectsWithTagsTest {
                     .assemble()
                     .unwrap();
 
-            Assertions.assertTrue(model.getShapeIndex().getShape(ShapeId.from("foo.baz#Integer")).isPresent());
-            Assertions.assertTrue(model.getShapeIndex().getShape(ShapeId.from("foo.baz#Float")).isPresent());
-            Assertions.assertTrue(model.getShapeIndex().getShape(ShapeId.from("smithy.example#Baz")).isPresent());
+            Assertions.assertTrue(model.getShape(ShapeId.from("foo.baz#Integer")).isPresent());
+            Assertions.assertTrue(model.getShape(ShapeId.from("foo.baz#Float")).isPresent());
+            Assertions.assertTrue(model.getShape(ShapeId.from("smithy.example#Baz")).isPresent());
         });
     }
 }

--- a/src/main/java/software/amazon/smithy/gradle/SmithyPlugin.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyPlugin.java
@@ -39,7 +39,7 @@ import software.amazon.smithy.utils.ListUtils;
  */
 public final class SmithyPlugin implements Plugin<Project> {
 
-    private static final String DEFAULT_CLI_VERSION = "0.9.7";
+    private static final String DEFAULT_CLI_VERSION = "1.0.0";
     private static final List<String> SOURCE_DIRS = ListUtils.of(
             "model", "src/$name/smithy", "src/$name/resources/META-INF/smithy");
 


### PR DESCRIPTION
This commit updates the Smithy Gradle Plugin to use the GA release
of Smithy. It updates for a few breaking changes in addition to the
dependency and versioning updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
