### PR TITLE
Update Gradle publish plugin to 0.11.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     checkstyle
     jacoco
     id("com.github.spotbugs") version "1.6.10"
-    id("com.gradle.plugin-publish") version "0.10.0"
+    id("com.gradle.plugin-publish") version "0.11.0"
 }
 
 group = "software.amazon.smithy"


### PR DESCRIPTION
Updates com.gradle.plugin-publish plugin to version 0.11.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
