### PR TITLE
Use outputDirectory to resolve plugin path

### DIFF
--- a/examples/output-directory-with-projection/build.gradle.kts
+++ b/examples/output-directory-with-projection/build.gradle.kts
@@ -1,0 +1,33 @@
+// This example writes Smithy build artifacts to a specified directory and
+// places a projected version of the model into the JAR.
+
+plugins {
+    id("software.amazon.smithy").version("0.5.2")
+}
+
+buildscript {
+    repositories {
+        mavenLocal()
+    }
+    dependencies {
+        // This dependency is required to build the model.
+        classpath("software.amazon.smithy:smithy-aws-traits:[1.0, 2.0[")
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("software.amazon.smithy:smithy-model:[1.0, 2.0[")
+
+    // This dependency is used in the projected model, so it's requird here too.
+    implementation("software.amazon.smithy:smithy-aws-traits:[1.0, 2.0[")
+}
+
+configure<software.amazon.smithy.gradle.SmithyExtension> {
+    projection = "foo"
+    outputDirectory = file("/tmp/output-directory")
+}

--- a/examples/output-directory-with-projection/build.gradle.kts
+++ b/examples/output-directory-with-projection/build.gradle.kts
@@ -29,5 +29,6 @@ dependencies {
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {
     projection = "foo"
-    outputDirectory = file("/tmp/output-directory")
+    // This could also be set to another directory outside the project's buildDir entirely.
+    outputDirectory = file(project.getBuildDir().toPath().resolve("nested-output-directory").toFile())
 }

--- a/examples/output-directory-with-projection/model/main.smithy
+++ b/examples/output-directory-with-projection/model/main.smithy
@@ -1,0 +1,8 @@
+namespace smithy.example
+
+structure Baz {
+  foo: String
+}
+
+@aws.auth#unsignedPayload
+operation Foo {}

--- a/examples/output-directory-with-projection/settings.gradle.kts
+++ b/examples/output-directory-with-projection/settings.gradle.kts
@@ -1,0 +1,7 @@
+rootProject.name = "projection"
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+    }
+}

--- a/examples/output-directory-with-projection/smithy-build.json
+++ b/examples/output-directory-with-projection/smithy-build.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "projections": {
+    "foo": {}
+  }
+}

--- a/examples/output-directory/build.gradle.kts
+++ b/examples/output-directory/build.gradle.kts
@@ -27,5 +27,6 @@ dependencies {
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {
-    outputDirectory = file("/tmp/output-directory")
+    // This could also be set to another directory outside the project's buildDir entirely.
+    outputDirectory = file(project.getBuildDir().toPath().resolve("nested-output-directory").toFile())
 }

--- a/examples/output-directory/build.gradle.kts
+++ b/examples/output-directory/build.gradle.kts
@@ -1,0 +1,31 @@
+// This example writes Smithy build artifacts to a specified directory.
+
+plugins {
+    id("software.amazon.smithy").version("0.5.2")
+}
+
+buildscript {
+    repositories {
+        mavenLocal()
+    }
+    dependencies {
+        // This dependency is required to build the model.
+        classpath("software.amazon.smithy:smithy-aws-traits:[1.0, 2.0[")
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("software.amazon.smithy:smithy-model:[1.0, 2.0[")
+
+    // This dependency is used in the projected model, so it's requird here too.
+    implementation("software.amazon.smithy:smithy-aws-traits:[1.0, 2.0[")
+}
+
+configure<software.amazon.smithy.gradle.SmithyExtension> {
+    outputDirectory = file("/tmp/output-directory")
+}

--- a/examples/output-directory/model/main.smithy
+++ b/examples/output-directory/model/main.smithy
@@ -1,0 +1,8 @@
+namespace smithy.example
+
+structure Baz {
+  foo: String
+}
+
+@aws.auth#unsignedPayload
+operation Foo {}

--- a/examples/output-directory/settings.gradle.kts
+++ b/examples/output-directory/settings.gradle.kts
@@ -1,0 +1,7 @@
+rootProject.name = "projection"
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+    }
+}

--- a/examples/output-directory/smithy-build.json
+++ b/examples/output-directory/smithy-build.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0",
+  "projections": {}
+}

--- a/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Paths;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+
+public class OutputDirectoryTest {
+    @Test
+    public void testOutputDirectory() {
+        File buildDir = Paths.get("/tmp/build-directory").toFile();
+        File outputDir = Paths.get("/tmp/output-directory").toFile();
+        try {
+            Utils.copyProject("output-directory", buildDir);
+            BuildResult result = GradleRunner.create()
+                    .withProjectDir(buildDir)
+                    .withArguments("clean", "build", "--stacktrace")
+                    .build();
+            Utils.assertSmithyBuildRan(result);
+            Utils.assertValidationRan(result);
+            Utils.assertArtifactsCreated(outputDir,
+                    "source/build-info/smithy-build-info.json",
+                    "source/model/model.json",
+                    "source/sources/main.smithy",
+                    "source/sources/manifest");
+            Utils.assertArtifactsCreated(buildDir,
+                    "build/libs/projection.jar");
+            Utils.assertJarContains(buildDir,
+                    "build/libs/projection.jar",
+                    "META-INF/smithy/manifest",
+                    "META-INF/smithy/model.json");
+        } catch (UncheckedIOException e) {
+            throw e;
+        } finally {
+                Utils.deleteTempDir(buildDir);
+                Utils.deleteTempDir(outputDir);
+        }
+    }
+}

--- a/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
@@ -18,7 +18,8 @@ package software.amazon.smithy.gradle;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
@@ -26,10 +27,12 @@ import org.junit.jupiter.api.Test;
 public class OutputDirectoryTest {
     @Test
     public void testOutputDirectory() {
-        File buildDir = Paths.get("/tmp/build-directory").toFile();
-        File outputDir = Paths.get("/tmp/output-directory").toFile();
+        String projectName = "output-directory";
+        Path buildDirPath = Utils.createTempDir(projectName);
+        File buildDir = buildDirPath.toFile();
+        File outputDir = buildDirPath.resolve("build").resolve("nested-output-directory").toFile();
         try {
-            Utils.copyProject("output-directory", buildDir);
+            Utils.copyProject(projectName, buildDir);
             BuildResult result = GradleRunner.create()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
@@ -46,12 +49,11 @@ public class OutputDirectoryTest {
             Utils.assertJarContains(buildDir,
                     "build/libs/projection.jar",
                     "META-INF/smithy/manifest",
-                    "META-INF/smithy/model.json");
+                    "META-INF/smithy/main.smithy");
         } catch (UncheckedIOException e) {
             throw e;
         } finally {
-                Utils.deleteTempDir(buildDir);
-                Utils.deleteTempDir(outputDir);
+            Utils.deleteTempDir(buildDir);
         }
     }
 }

--- a/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Paths;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+
+public class OutputDirectoryWithProjectionTest {
+    @Test
+    public void testOutputDirectory() {
+        File buildDir = Paths.get("/tmp/build-directory").toFile();
+        File outputDir = Paths.get("/tmp/output-directory").toFile();
+        try {
+            Utils.copyProject("output-directory-with-projection", buildDir);
+            BuildResult result = GradleRunner.create()
+                    .withProjectDir(buildDir)
+                    .withArguments("clean", "build", "--stacktrace")
+                    .build();
+            Utils.assertSmithyBuildRan(result);
+            Utils.assertValidationRan(result);
+            Utils.assertArtifactsCreated(outputDir,
+                    "source/build-info/smithy-build-info.json",
+                    "source/model/model.json",
+                    "source/sources/main.smithy",
+                    "source/sources/manifest",
+                    "foo/build-info/smithy-build-info.json",
+                    "foo/model/model.json",
+                    "foo/sources/manifest",
+                    "foo/sources/model.json");
+            Utils.assertArtifactsCreated(buildDir,
+                    "build/libs/projection.jar");
+            Utils.assertJarContains(buildDir,
+                    "build/libs/projection.jar",
+                    "META-INF/smithy/manifest",
+                    "META-INF/smithy/model.json");
+        } catch (UncheckedIOException e) {
+            throw e;
+        } finally {
+                Utils.deleteTempDir(buildDir);
+                Utils.deleteTempDir(outputDir);
+        }
+    }
+}

--- a/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
@@ -18,7 +18,8 @@ package software.amazon.smithy.gradle;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
@@ -26,10 +27,12 @@ import org.junit.jupiter.api.Test;
 public class OutputDirectoryWithProjectionTest {
     @Test
     public void testOutputDirectory() {
-        File buildDir = Paths.get("/tmp/build-directory").toFile();
-        File outputDir = Paths.get("/tmp/output-directory").toFile();
+        String projectName = "output-directory-with-projection";
+        Path buildDirPath = Utils.createTempDir(projectName);
+        File buildDir = buildDirPath.toFile();
+        File outputDir = buildDirPath.resolve("build").resolve("nested-output-directory").toFile();
         try {
-            Utils.copyProject("output-directory-with-projection", buildDir);
+            Utils.copyProject(projectName, buildDir);
             BuildResult result = GradleRunner.create()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
@@ -54,8 +57,7 @@ public class OutputDirectoryWithProjectionTest {
         } catch (UncheckedIOException e) {
             throw e;
         } finally {
-                Utils.deleteTempDir(buildDir);
-                Utils.deleteTempDir(outputDir);
+            Utils.deleteTempDir(buildDir);
         }
     }
 }

--- a/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -67,6 +67,13 @@ public final class SmithyUtils {
      * @return Returns the resolved path.
      */
     public static Path getProjectionPluginPath(Project project, String projection, String plugin) {
+        SmithyExtension extension = getSmithyExtension(project);
+        if (extension.getOutputDirectory() != null) {
+            return extension.getOutputDirectory()
+                    .toPath()
+                    .resolve(projection)
+                    .resolve(plugin);
+        }
         return project.getBuildDir().toPath()
                 .resolve(SMITHY_PROJECTIONS)
                 .resolve(project.getName())


### PR DESCRIPTION
Currently, if an `outputDirectory` [extension property](https://awslabs.github.io/smithy/1.0/guides/building-models/gradle-plugin.html#smithy-extension-properties) has been configured, the `smithyBuildJar` task will not resolve the correct projection plugin path.  If a projection has been configured, a GradleException will be thrown, however, if no projection is configured and the `sources` plugin is being used, only a warning will be emitted.  This CR updates the resolution of the plugin path when an `outputDirectory` has been configured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
