### PR TITLE
Add github actions ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    name: Java ${{ matrix.java }} ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [8, 11]
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout smithy-gradle-plugin
+        uses: actions/checkout@v2
+        with:
+          path: smithy-gradle-plugin
+
+      # We checkout smithy main here since we will often require changes that
+      # have not yet been released but have been merged.
+      - name: Checkout smithy main branch
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/smithy
+          path: smithy
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Publish smithy main to maven local
+        run: |
+          cd smithy
+          ./gradlew clean publishToMavenLocal
+
+      - name: Clean and build smithy-gradle-plugin
+        run: |
+          cd smithy-gradle-plugin
+          ./gradlew clean build -Plog-tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Smithy Gradle Plugin
+[![Build Status](https://github.com/awslabs/smithy-gradle-plugin/workflows/ci/badge.svg)](https://github.com/awslabs/smithy-gradle-plugin/workflows/ci)
 
 This project integrates Smithy with Gradle. This plugin can build artifacts
 from Smithy models, generate JARs that contain Smithy models found in Java


### PR DESCRIPTION
*Description of changes:*

Adds CI using GitHub actions. Since none of this takes effect until some variant of actions is already in the main branch, here's a pr on my fork demonstrating it in action: https://github.com/JordonPhillips/smithy-gradle-plugin/pull/1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
