### PR TITLE
Update checkstyle to allow 2021 copyright

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -30,9 +30,9 @@
     </module>
 
     <!-- Files must contain a copyright header. -->
-    <module name="Header">
+    <module name="RegexpHeader">
         <property name="header"
-                  value="/*\n * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.\n"/>
+                  value="/\*\n \* Copyright 20(19|21) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 


### PR DESCRIPTION
Update checkstyle to allow 2021 copyright

n.b. checkstyle was never updated to allow 2020 copyright.  This is set to accept 2019 and 2021, but not 2020, as no headers should use 2020.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
