### PR TITLE
Fix ZipFile signature issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Smithy Gradle Plugin Changelog
 
+## 0.5.3 (TBD)
+
+* Fixed the `ZipFile invalid LOC header (bad signature)` error that was caused by
+  changing resource files.
+
 ## 0.5.2 (2020-09-30)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following example configures a project to use the Smithy Gradle plugin:
 
 ```kotlin
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 group = "software.amazon.smithy"
-version = "0.5.2"
+version = "0.5.3"
 
 dependencies {
     implementation("software.amazon.smithy:smithy-model:[1.0, 2.0[")

--- a/examples/adds-tags/build.gradle.kts
+++ b/examples/adds-tags/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example adds a Smithy tag to the built JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 group = "software.amazon.smithy"

--- a/examples/disable-jar/build.gradle.kts
+++ b/examples/disable-jar/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example builds Smithy models but does not create a JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 repositories {

--- a/examples/failure-cases/invalid-projection/build.gradle.kts
+++ b/examples/failure-cases/invalid-projection/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example attempts to use an invalid projection. The build will fail.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 repositories {

--- a/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
+++ b/examples/failure-cases/missing-runtime-dependency/build.gradle.kts
@@ -4,7 +4,7 @@
 // plugin validates the JAR with Smithy model discovery.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 buildscript {

--- a/examples/failure-cases/syntax-error/build.gradle.kts
+++ b/examples/failure-cases/syntax-error/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example fails to build due to a syntax error.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 repositories {

--- a/examples/multi-project/consumer/build.gradle.kts
+++ b/examples/multi-project/consumer/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 dependencies {

--- a/examples/multiple-sources/build.gradle.kts
+++ b/examples/multiple-sources/build.gradle.kts
@@ -4,7 +4,7 @@
 // - src/main/resources/META-INF/smithy
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 repositories {

--- a/examples/no-models/build.gradle.kts
+++ b/examples/no-models/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example is an integration test to ensure that projects with no models do not fail.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 group = "software.amazon.smithy"

--- a/examples/output-directory-with-projection/build.gradle.kts
+++ b/examples/output-directory-with-projection/build.gradle.kts
@@ -2,7 +2,7 @@
 // places a projected version of the model into the JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 buildscript {

--- a/examples/output-directory/build.gradle.kts
+++ b/examples/output-directory/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example writes Smithy build artifacts to a specified directory.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 buildscript {

--- a/examples/projection/build.gradle.kts
+++ b/examples/projection/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example places a projected version of the model into the JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 buildscript {

--- a/examples/projects-with-tags/build.gradle.kts
+++ b/examples/projects-with-tags/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example places a projected version of the model into the JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 buildscript {

--- a/examples/scans-for-cli-version/build.gradle.kts
+++ b/examples/scans-for-cli-version/build.gradle.kts
@@ -2,7 +2,7 @@
 // found by scanning buildScript dependencies.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 group = "software.amazon.smithy"

--- a/examples/smithy-build-task/build.gradle.kts
+++ b/examples/smithy-build-task/build.gradle.kts
@@ -6,7 +6,7 @@ import software.amazon.smithy.gradle.tasks.SmithyBuild
 // and the classpath used when building.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 repositories {

--- a/examples/source-projection/build.gradle.kts
+++ b/examples/source-projection/build.gradle.kts
@@ -1,7 +1,7 @@
 // This example builds the model and places it in the JAR.
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 repositories {


### PR DESCRIPTION
Fixed the `ZipFile invalid LOC header (bad signature)` error that was
caused by changing resource files. This was fixed by disabling
URLConnection caching globally with URLConnection#setDefaultUseCaches
to false.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
