### PR TITLE
Testing projecting validation-model without docs

### DIFF
--- a/examples/projection/build.gradle.kts
+++ b/examples/projection/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         // This dependency is required to build the model.
-        classpath("software.amazon.smithy:smithy-aws-traits:[1.0, 2.0[")
+        classpath("software.amazon.smithy:smithy-validation-model:[1.0, 2.0[")
     }
 }
 
@@ -21,9 +21,6 @@ repositories {
 
 dependencies {
     implementation("software.amazon.smithy:smithy-model:[1.0, 2.0[")
-
-    // This dependency is used in the projected model, so it's requird here too.
-    implementation("software.amazon.smithy:smithy-aws-traits:[1.0, 2.0[")
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {

--- a/examples/projection/model/main.smithy
+++ b/examples/projection/model/main.smithy
@@ -1,8 +1,0 @@
-namespace smithy.example
-
-structure Baz {
-  foo: String
-}
-
-@aws.auth#unsignedPayload
-operation Foo {}

--- a/examples/projection/settings.gradle.kts
+++ b/examples/projection/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
     repositories {
         mavenLocal()
         // Uncomment these to use the published version of the plugin from your preferred source.
-        // gradlePluginPortal()
-        // mavenCentral()
+        gradlePluginPortal()
+        mavenCentral()
     }
 }

--- a/examples/projection/smithy-build.json
+++ b/examples/projection/smithy-build.json
@@ -1,6 +1,15 @@
 {
   "version": "1.0",
   "projections": {
-    "foo": {}
+      "foo": {
+            "transforms": [
+                {
+                    "name": "excludeTraits",
+                    "args": {
+                        "traits": ["smithy.api#documentation"]
+                    }
+                }
+            ]
+      }
   }
 }


### PR DESCRIPTION
Question: How can I get the built jar when building a projection to contain the projected model? Are projectionSourceTags necessary?

```
% gradle build
% cd build/libs
% jar xvf projection.jar
  created: META-INF/
 inflated: META-INF/MANIFEST.MF
  created: META-INF/smithy/
 inflated: META-INF/smithy/model.json
 inflated: META-INF/smithy/manifest
% cat META-INF/smithy/model.json
{
    "smithy": "1.0",
    "shapes": {}
}
```

The jar does not have the model.

The projection is correctly removing the documentation trait:
```
cat build/smithyprojections/projection/foo/model/model.json
{
    "smithy": "1.0",
    "shapes": {
        "smithy.framework#ValidationException": {
            "type": "structure",
            "members": {
                "message": {
                    "target": "smithy.api#String",
                    "traits": {
                        "smithy.api#required": {}
                    }
                },
                "fieldList": {
                    "target": "smithy.framework#ValidationExceptionFieldList"
                }
            },
            "traits": {
                "smithy.api#error": "client"
            }
        },
        "smithy.framework#ValidationExceptionField": {
            "type": "structure",
            "members": {
                "path": {
                    "target": "smithy.api#String",
                    "traits": {
                        "smithy.api#required": {}
                    }
                },
                "message": {
                    "target": "smithy.api#String",
                    "traits": {
                        "smithy.api#required": {}
                    }
                }
            }
        },
        "smithy.framework#ValidationExceptionFieldList": {
            "type": "list",
            "member": {
                "target": "smithy.framework#ValidationExceptionField"
            }
        }
    }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
