### PR TITLE
Separate Smithy-Tags into separate Task

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsTask.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsTask.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.gradle.tasks;
+
+import java.util.Set;
+import java.util.TreeSet;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.jvm.tasks.Jar;
+import software.amazon.smithy.gradle.SmithyExtension;
+import software.amazon.smithy.gradle.SmithyUtils;
+
+/**
+ * Adds Smithy-Tags to the JAR built by the {@link Jar} Task.
+ * This Task does not define any outputs. So it will always be executed before the Jar Task.
+ */
+public class SmithyTagsTask extends DefaultTask {
+
+    private Set<String> tags = new TreeSet<>();
+
+    /**
+     * Get the tags that are added to the JAR.
+     *
+     * <p>These tags are placed in the META-INF/MANIFEST.MF attribute named
+     * "Smithy-Tags" as a comma separated list. JARs with Smithy-Tags can be
+     * queried when building projections so that the Smithy models found in
+     * each matching JAR are placed into the projection JAR.
+     *
+     * @return Returns the Smithy-Tags values that will be added to the created JAR.
+     */
+    @Input
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Sets the tags that are added that the JAR manifest in "Smithy-Tags".
+     *
+     * @param tags Smithy-Tags to add to the JAR.
+     * @see #getTags()
+     */
+    public void setTags(Set<String> tags) {
+        this.tags.addAll(tags);
+    }
+
+    @TaskAction
+    public void execute() {
+        writeHeading("Running smithyTags");
+
+        if (!getProject().getTasks().getByName("jar").getEnabled()) {
+            getLogger().info("'jar' task is not enabled, so nothing to do in 'smithyTags'");
+            return;
+        }
+
+        // Configure the task from the extension if things aren't already setup.
+        SmithyExtension extension = SmithyUtils.getSmithyExtension(getProject());
+        tags.addAll(extension.getTags());
+
+        // Always add the group, the group + ":" + name, and the group + ":" + name + ":" + version as tags.
+        if (!getProject().getGroup().toString().isEmpty()) {
+            tags.add(getProject().getGroup().toString());
+            tags.add(getProject().getGroup() + ":" + getProject().getName());
+            tags.add(getProject().getGroup() + ":" + getProject().getName() + ":" + getProject().getVersion());
+            getLogger().info("Adding built-in Smithy JAR tags: {}", tags);
+        }
+
+        getProject().getTasks().withType(Jar.class, task -> {
+            getLogger().info("Adding tags to manifest: {}", tags);
+            Attributes attributes = task.getManifest().getAttributes();
+            attributes.put("Smithy-Tags", String.join(", ", tags));
+        });
+    }
+
+    private void writeHeading(String text) {
+        StyledTextOutput output = getServices().get(StyledTextOutputFactory.class)
+                .create("smithy")
+                .style(StyledTextOutput.Style.Header);
+        output.println(text);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/smithy-gradle-plugin/issues/46

*Description of changes:*
As described in the issue, Smithy-Tags logic doesn't run the 2nd time. So this change separate Smithy-Tags logic into a separate Task. So that it is always run before the Jar Task.

*Testing:*
With this change, running `gradle jar -info` the 2nd time shows:
```
> Task :smithyBuildJar UP-TO-DATE
Caching disabled for task ':smithyBuildJar' because:
  Build cache is disabled
Skipping task ':smithyBuildJar' as it is up-to-date.
:smithyBuildJar (Thread[Execution worker for ':',5,main]) completed. Took 0.009 secs.
:processResources (Thread[Execution worker for ':',5,main]) started.

> Task :processResources UP-TO-DATE
file or directory '/Volumes/workplace/github/smithy-gradle-plugin/examples/adds-tags/src/main/resources', not found
Caching disabled for task ':processResources' because:
  Build cache is disabled
Skipping task ':processResources' as it is up-to-date.
:processResources (Thread[Execution worker for ':',5,main]) completed. Took 0.002 secs.
:classes (Thread[Execution worker for ':',5,main]) started.

> Task :classes UP-TO-DATE
Skipping task ':classes' as it has no actions.
:classes (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:smithyTags (Thread[Execution worker for ':',5,main]) started.

> Task :smithyTags
Caching disabled for task ':smithyTags' because:
  Build cache is disabled
Task ':smithyTags' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Running smithyTags
Adding built-in Smithy JAR tags: [Baz, Foo, software.amazon.smithy, software.amazon.smithy:adds-tags, software.amazon.smithy:adds-tags:9.9.9]
Adding tags to manifest: [Baz, Foo, software.amazon.smithy, software.amazon.smithy:adds-tags, software.amazon.smithy:adds-tags:9.9.9]
:smithyTags (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:jar (Thread[Execution worker for ':',5,main]) started.

> Task :jar UP-TO-DATE
file or directory '/Volumes/workplace/github/smithy-gradle-plugin/examples/adds-tags/build/classes/java/main', not found
Caching disabled for task ':jar' because:
  Build cache is disabled
Skipping task ':jar' as it is up-to-date.
:jar (Thread[Execution worker for ':',5,main]) completed. Took 0.001 secs.

BUILD SUCCESSFUL in 532ms
4 actionable tasks: 1 executed, 3 up-to-date
```

Notice 
```
Task ':smithyTags' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
```
and the logic is run. Since the tags are added again, the `jar` task doesn't find any changes and is UP-TO-DATE, meaning the jar isn't recreated, i.e., jar from the 1st run, with the Smithy-Tags present, is retained.


Another test case:
```
cd examples/adds-jar
gradle clean
gradle jar # (A) This works
gradle jar # (B) This had no change to build/tmp/jar/MANIFEST.MF or the jar.

# Now I edited the build.gradle.kts to change the `tags` value in SmithyExtension
gradle jar # (C) The smithyTags task runs, with the new tags, so there is change to build/tmp/jar/MANIFEST.MF and new jar with the new Smithy-Tags is created.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
