### PR TITLE
Using a Action (in Jar Task) for Smithy-Tags

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsAction.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsAction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.gradle.tasks;
+
+import java.util.Set;
+import java.util.TreeSet;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.tasks.Input;
+import org.gradle.jvm.tasks.Jar;
+import software.amazon.smithy.gradle.SmithyExtension;
+import software.amazon.smithy.gradle.SmithyUtils;
+
+/**
+ * Adds Smithy-Tags to the JAR built by the {@link Jar} Task.
+ * This Task does not define any outputs. So it will always be executed before the Jar Task.
+ */
+public class SmithyTagsAction implements Action<Task> {
+
+    private Set<String> tags = new TreeSet<>();
+
+    /**
+     * Get the tags that are added to the JAR.
+     *
+     * <p>These tags are placed in the META-INF/MANIFEST.MF attribute named
+     * "Smithy-Tags" as a comma separated list. JARs with Smithy-Tags can be
+     * queried when building projections so that the Smithy models found in
+     * each matching JAR are placed into the projection JAR.
+     *
+     * @return Returns the Smithy-Tags values that will be added to the created JAR.
+     */
+    @Input
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Sets the tags that are added that the JAR manifest in "Smithy-Tags".
+     *
+     * @param tags Smithy-Tags to add to the JAR.
+     * @see #getTags()
+     */
+    public void setTags(Set<String> tags) {
+        this.tags.addAll(tags);
+    }
+
+    @Override
+    public void execute(Task task) {
+        writeHeading("Running smithyTags");
+
+        if (!(task instanceof Jar)) {
+            throw new GradleException("SmithyTagsAction can only be used with the Jar task type");
+        }
+
+        Jar jar = (Jar) task;
+
+        Project project = jar.getProject();
+
+        if (!jar.isEnabled()) {
+            jar.getLogger().info("'jar' task is not enabled, so nothing to do in 'smithyTags'");
+            return;
+        }
+
+        // Configure the task from the extension if things aren't already setup.
+        SmithyExtension extension = SmithyUtils.getSmithyExtension(project);
+        tags.addAll(extension.getTags());
+
+        // Always add the group, the group + ":" + name, and the group + ":" + name + ":" + version as tags.
+        if (!project.getGroup().toString().isEmpty()) {
+            tags.add(project.getGroup().toString());
+            tags.add(project.getGroup() + ":" + project.getName());
+            tags.add(project.getGroup() + ":" + project.getName() + ":" + project.getVersion());
+            jar.getLogger().info("Adding built-in Smithy JAR tags: {}", tags);
+        }
+
+        jar.getLogger().info("Adding tags to manifest: {}", tags);
+        Attributes attributes = jar.getManifest().getAttributes();
+        attributes.put("Smithy-Tags", String.join(", ", tags));
+    }
+
+    private void writeHeading(String text) {
+//        StyledTextOutput output = getServices().get(StyledTextOutputFactory.class)
+//                .create("smithy")
+//                .style(StyledTextOutput.Style.Header);
+//        output.println(text);
+    }
+}

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsTask.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsTask.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.gradle.tasks;
+
+import java.util.Set;
+import java.util.TreeSet;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.jvm.tasks.Jar;
+import software.amazon.smithy.gradle.SmithyExtension;
+import software.amazon.smithy.gradle.SmithyUtils;
+
+/**
+ * Adds Smithy-Tags to the JAR built by the {@link Jar} Task.
+ * This Task does not define any outputs. So it will always be executed before the Jar Task.
+ */
+public class SmithyTagsTask extends DefaultTask {
+
+    private Set<String> tags = new TreeSet<>();
+
+    /**
+     * Get the tags that are added to the JAR.
+     *
+     * <p>These tags are placed in the META-INF/MANIFEST.MF attribute named
+     * "Smithy-Tags" as a comma separated list. JARs with Smithy-Tags can be
+     * queried when building projections so that the Smithy models found in
+     * each matching JAR are placed into the projection JAR.
+     *
+     * @return Returns the Smithy-Tags values that will be added to the created JAR.
+     */
+    @Input
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Sets the tags that are added that the JAR manifest in "Smithy-Tags".
+     *
+     * @param tags Smithy-Tags to add to the JAR.
+     * @see #getTags()
+     */
+    public void setTags(Set<String> tags) {
+        this.tags.addAll(tags);
+    }
+
+    @TaskAction
+    public void execute() {
+        writeHeading("Running smithyTags");
+
+        if (!getProject().getTasks().getByName("jar").getEnabled()) {
+            getLogger().info("'jar' task is not enabled, so nothing to do in 'smithyTags'");
+            return;
+        }
+
+        // Configure the task from the extension if things aren't already setup.
+        SmithyExtension extension = SmithyUtils.getSmithyExtension(getProject());
+        tags.addAll(extension.getTags());
+
+        // Always add the group, the group + ":" + name, and the group + ":" + name + ":" + version as tags.
+        if (!getProject().getGroup().toString().isEmpty()) {
+            tags.add(getProject().getGroup().toString());
+            tags.add(getProject().getGroup() + ":" + getProject().getName());
+            tags.add(getProject().getGroup() + ":" + getProject().getName() + ":" + getProject().getVersion());
+            getLogger().info("Adding built-in Smithy JAR tags: {}", tags);
+        }
+
+        getProject().getTasks().withType(Jar.class, task -> {
+            getLogger().info("Adding tags to manifest: {}", tags);
+            Attributes attributes = task.getManifest().getAttributes();
+            attributes.put("Smithy-Tags", String.join(", ", tags));
+        });
+    }
+
+    private void writeHeading(String text) {
+        StyledTextOutput output = getServices().get(StyledTextOutputFactory.class)
+                .create("smithy")
+                .style(StyledTextOutput.Style.Header);
+        output.println(text);
+    }
+}


### PR DESCRIPTION
This is an alternate to https://github.com/awslabs/smithy-gradle-plugin/pull/47. In that PR, having ability to do `gradle smithyTags` seemed odd. So I tried adding an Action to the Jar task itself instead.

One drawback of this solution is that I don't know how Action inputs work. I did add `@Input` annotation to the SmithyTagsAction. I tested this case:
```
cd examples/adds-jar
gradle clean
gradle jar # (A) This works
gradle jar # (B) This is fine too, the jar is unchanged, though I did notice that build/tmp/jar/MANIFEST.MF was changed and didn't have Smithy-Tags. But the jar Task was considered UP-TO-DATE and no new jar

# Now I edited the build.gradle.kts to change the `tags` value in SmithyExtension
gradle jar # (C) However, this had no change to build/tmp/jar/MANIFEST.MF or the jar. So the new `tags` from build.gradle.kts are NOT picked up.
```

This PR does not pick up changes to `tags` in build.gradle.kts. But https://github.com/awslabs/smithy-gradle-plugin/pull/47 works fine for that case. So preferring that PR over this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
