### PR TITLE
Fix buildDir not being respected

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -169,9 +169,8 @@ public final class SmithyUtils {
      * @return Returns the default output directory.
      */
     private static File getProjectionOutputDir(Project project) {
-        return project.getProjectDir()
+        return project.getBuildDir()
                 .toPath()
-                .resolve("build")
                 .resolve(SMITHY_PROJECTIONS)
                 .resolve(project.getName())
                 .toFile();


### PR DESCRIPTION
*Issue #, if available:*
closes https://github.com/awslabs/smithy-gradle-plugin/issues/51

*Description of changes:*
Use the actual project build directory rather than hard coding it to `projectDir/build`. 

I haven't tested this locally but I'm assuming the integration tests would catch any issues with this kind of change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
