### PR TITLE
Update Gradle plugin to work with new Smithy CLI

### DIFF
--- a/src/it/java/software/amazon/smithy/gradle/DisableJarTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/DisableJarTest.java
@@ -30,7 +30,6 @@ public class DisableJarTest {
                     .build();
 
             Utils.assertSmithyBuildRan(result);
-            Utils.assertValidationDidNotRun(result);
             Utils.assertArtifactsCreated(buildDir,
                     "build/smithyprojections/disable-jar/source/build-info/smithy-build-info.json",
                     "build/smithyprojections/disable-jar/source/model/model.json",

--- a/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
@@ -34,7 +34,6 @@ public class SmithyBuildTaskTest {
                 .build();
 
         Utils.assertSmithyBuildDidNotRun(result);
-        Utils.assertValidationDidNotRun(result);
         Utils.assertArtifactsCreated(
                 buildDir,
                 "build/smithyprojections/smithy-build-task/source/build-info/smithy-build-info.json",

--- a/src/it/java/software/amazon/smithy/gradle/Utils.java
+++ b/src/it/java/software/amazon/smithy/gradle/Utils.java
@@ -27,6 +27,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
@@ -105,11 +106,8 @@ public final class Utils {
     }
 
     public static void assertValidationRan(BuildResult result) {
-        Assertions.assertTrue(result.getOutput().contains("Smithy validation complete"));
-    }
-
-    public static void assertValidationDidNotRun(BuildResult result) {
-        Assertions.assertFalse(result.getOutput().contains("Smithy validation complete"));
+        // e.g., Validated 120 shapes
+        Assertions.assertTrue(result.getOutput().contains("shapes"));
     }
 
     public static void assertArtifactsCreated(File projectDir, String... paths) {

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkerExecutor;
 import software.amazon.smithy.cli.BuildParameterBuilder;
 import software.amazon.smithy.gradle.SmithyExtension;
 import software.amazon.smithy.gradle.SmithyUtils;
@@ -207,7 +208,8 @@ public class SmithyBuildJar extends BaseSmithyTask {
 
         BuildParameterBuilder.Result result = builder.build();
         Object[] jars = result.classpath.split(System.getProperty("path.separator"));
-        SmithyUtils.executeCli(getProject(), result.args, getProject().files(jars));
+        WorkerExecutor executor = getServices().get(WorkerExecutor.class);
+        SmithyUtils.executeCli(executor, getProject(), result.args, getProject().files(jars));
 
         // Copy generated files where they're needed and register source sets.
         try {

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyCliTask.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyCliTask.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
+import org.gradle.workers.WorkerExecutor;
 import software.amazon.smithy.gradle.SmithyUtils;
 
 /**
@@ -221,6 +222,7 @@ abstract class SmithyCliTask extends BaseSmithyTask {
             });
         }
 
-        SmithyUtils.executeCli(getProject(), args, cliClasspath);
+        WorkerExecutor executor = getServices().get(WorkerExecutor.class);
+        SmithyUtils.executeCli(executor, getProject(), args, cliClasspath);
     }
 }


### PR DESCRIPTION
The Smithy CLI was updated to change some of its output, and remove
harder to test behaviors (like using a global variable to determine
where to send output). This commit updates the Gradle plugin to work
with these updates, but the plugin will also continue to work with older
versions of the CLI too.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
