### PR TITLE
Make failed tests something we can actually fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,14 +15,16 @@
 
 import com.github.spotbugs.snom.Effort
 import com.github.spotbugs.snom.SpotBugsTask
+import com.adarshr.gradle.testlogger.TestLoggerExtension;
 
 plugins {
     `java-gradle-plugin`
     `maven-publish`
     checkstyle
     jacoco
-    id("com.github.spotbugs") version "4.7.0"
+    id("com.github.spotbugs") version "4.7.1"
     id("com.gradle.plugin-publish") version "0.11.0"
+    id("com.adarshr.test-logger") version "3.2.0"
 }
 
 group = "software.amazon.smithy"
@@ -52,6 +54,23 @@ java {
 // Use Junit5's test runner.
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+configure<TestLoggerExtension> {
+    showExceptions = true
+    showStackTraces = true
+    showFullStackTraces = false
+    showCauses = true
+    showSummary = true
+    showPassed = true
+    showSkipped = true
+    showFailed = true
+    showOnlySlow = false
+    showStandardStreams = true
+    showPassedStandardStreams = false
+    showSkippedStandardStreams = false
+    showFailedStandardStreams = true
+    logLevel = LogLevel.LIFECYCLE
 }
 
 // Reusable license copySpec

--- a/src/it/java/software/amazon/smithy/gradle/AddsTagsTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/AddsTagsTest.java
@@ -32,6 +32,7 @@ public class AddsTagsTest {
     public void addsSmithyTagsToJars() {
         Utils.withCopy("adds-tags", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/DisableJarTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/DisableJarTest.java
@@ -24,6 +24,7 @@ public class DisableJarTest {
     public void testProjection() {
         Utils.withCopy("disable-jar", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/InvalidProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/InvalidProjectionTest.java
@@ -25,6 +25,7 @@ public class InvalidProjectionTest {
     public void testProjection() {
         Utils.withCopy("failure-cases/invalid-projection", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .buildAndFail();

--- a/src/it/java/software/amazon/smithy/gradle/MissingRuntimeDependencyTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/MissingRuntimeDependencyTest.java
@@ -25,6 +25,7 @@ public class MissingRuntimeDependencyTest {
     public void testProjection() {
         Utils.withCopy("failure-cases/missing-runtime-dependency", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .buildAndFail();

--- a/src/it/java/software/amazon/smithy/gradle/MultipleSourcesTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/MultipleSourcesTest.java
@@ -24,6 +24,7 @@ public class MultipleSourcesTest {
     public void testProjection() {
         Utils.withCopy("multiple-sources", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/NoModelsTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/NoModelsTest.java
@@ -24,6 +24,7 @@ public class NoModelsTest {
     public void createsJarWithNoModels() {
         Utils.withCopy("no-models", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
@@ -16,9 +16,7 @@
 package software.amazon.smithy.gradle;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
@@ -34,6 +32,7 @@ public class OutputDirectoryTest {
         try {
             Utils.copyProject(projectName, buildDir);
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
@@ -16,9 +16,7 @@
 package software.amazon.smithy.gradle;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
@@ -34,6 +32,7 @@ public class OutputDirectoryWithProjectionTest {
         try {
             Utils.copyProject(projectName, buildDir);
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
@@ -24,6 +24,7 @@ public class ProjectionTest {
     public void testProjection() {
         Utils.withCopy("projection", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/ProjectsWithTagsTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/ProjectsWithTagsTest.java
@@ -27,6 +27,7 @@ public class ProjectsWithTagsTest {
     public void testProjectionWithSourceTags() {
         Utils.withCopy("projects-with-tags", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/ScansForCliVersionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/ScansForCliVersionTest.java
@@ -24,6 +24,7 @@ public class ScansForCliVersionTest {
     public void scansForCliVersion() {
         Utils.withCopy("scans-for-cli-version", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
@@ -28,6 +28,7 @@ public class SmithyBuildTaskTest {
 
     private void run(File buildDir) {
         BuildResult result = GradleRunner.create()
+                .forwardOutput()
                 .withProjectDir(buildDir)
                 .withArguments("build", "--stacktrace")
                 .build();

--- a/src/it/java/software/amazon/smithy/gradle/SourceProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/SourceProjectionTest.java
@@ -24,6 +24,7 @@ public class SourceProjectionTest {
     public void testSourceProjection() {
         Utils.withCopy("source-projection", buildDir -> {
             BuildResult result = GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace", "--debug")
                     .build();

--- a/src/it/java/software/amazon/smithy/gradle/SyntaxErrorTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/SyntaxErrorTest.java
@@ -23,6 +23,7 @@ public class SyntaxErrorTest {
     public void testFailsWithSyntaxError() {
         Utils.withCopy("failure-cases/syntax-error", buildDir -> {
             GradleRunner.create()
+                    .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
                     .buildAndFail();


### PR DESCRIPTION
When tests failed in GitHub actions, we had no output to act on. This
change ensures that stderr/stdout are printed by each integration test,
and then uses a logging plugin to dump out this captured output on
failure so we can, ya know, understand how to fix weird platform
specific issues if they come up in integration tests.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
