### PR TITLE
Upgrade to com.gradle.plugin-publish plugin 1.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     checkstyle
     jacoco
     id("com.github.spotbugs") version "4.7.1"
-    id("com.gradle.plugin-publish") version "0.11.0"
+    id("com.gradle.plugin-publish") version "1.0.0"
     id("com.adarshr.test-logger") version "3.2.0"
 }
 
@@ -134,12 +134,7 @@ repositories {
 
 publishing {
     publications {
-        create<MavenPublication>("mavenJava") {
-            from(components["java"])
-
-            // Ship the source and javadoc jars.
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["javadocJar"])
+        create<MavenPublication>("pluginMaven") {
         }
     }
 }


### PR DESCRIPTION
# IGNORE THIS FOR NOW

---

*Issue #, if available:*

https://github.com/awslabs/smithy-gradle-plugin/issues/63

---

*Description of changes:*

Due to the unreliability of jcenter, use the latest version of
the com.gradle.plugin-publish plugin.

After upgrading, there were warning messages that artifacts were
being published to Maven Local multiple times, so removed the
redundant source / docs jar artifacts.

References:

- https://github.com/gradle/gradle/issues/10384

---

*Testing:*

1. Checkout `awslabs/smithy` and run `./gradlew publishToMavenLocal`
2. Checkout `awslabs/smithy-gradle-plugin`
    1. Ran `./gradlew clean build check publishToMavenLocal`
    2. Ran `tree ~/.m2/repository/software/amazon/smithy/smithy-gradle-plugin/0.6.0/`
    ```shell
    ~/.m2/repository/software/amazon/smithy/smithy-gradle-plugin/0.6.0/
    ├── smithy-gradle-plugin-0.6.0.jar
    ├── smithy-gradle-plugin-0.6.0-javadoc.jar
    ├── smithy-gradle-plugin-0.6.0.module
    ├── smithy-gradle-plugin-0.6.0.pom
    └── smithy-gradle-plugin-0.6.0-sources.jar
    ```

---

*Open Questions:*

Does publishing to Maven Central use the staged artifacts from Maven Local?

Removed these lines, but want to confirm that removing these lines does not affect what is published in a release:

```diff
-         create<MavenPublication>("mavenJava") {
-             from(components["java"])
- 
-             // Ship the source and javadoc jars.
-             artifact(tasks["sourcesJar"])
-             artifact(tasks["javadocJar"])
+         create<MavenPublication>("pluginMaven") {
          }
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
