### PR TITLE
Pass logging, debug, and stacktrace params to CLI

### DIFF
--- a/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
@@ -15,6 +15,10 @@
 
 package software.amazon.smithy.gradle;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
@@ -45,6 +49,47 @@ public class ProjectionTest {
                     "build/libs/projection.jar",
                     "META-INF/smithy/manifest",
                     "META-INF/smithy/model.json");
+        });
+    }
+
+    @Test
+    public void usesWarningLoggingByDefault() {
+        Utils.withCopy("projection", buildDir -> {
+            BuildResult result = GradleRunner.create()
+                    .forwardOutput()
+                    .withProjectDir(buildDir)
+                    .withArguments("clean", "build")
+                    .build();
+
+            // This string appears only when logging INFO or higher.
+            assertThat(result.getOutput(), not(containsString("[INFO] Validating")));
+        });
+    }
+
+    @Test
+    public void modifiesLogging() {
+        Utils.withCopy("projection", buildDir -> {
+            BuildResult result = GradleRunner.create()
+                    .forwardOutput()
+                    .withProjectDir(buildDir)
+                    .withArguments("clean", "build", "--info")
+                    .build();
+
+            assertThat(result.getOutput(), containsString("[INFO] Validating"));
+        });
+    }
+
+    @Test
+    public void usesDebugMode() {
+        Utils.withCopy("projection", buildDir -> {
+            BuildResult result = GradleRunner.create()
+                    .forwardOutput()
+                    .withProjectDir(buildDir)
+                    .withArguments("clean", "build", "--debug")
+                    .build();
+
+            // This string only appears with debug logging.
+            assertThat(result.getOutput(), containsString("Found Smithy model"));
         });
     }
 }


### PR DESCRIPTION
The Smithy CLI supports --debug, --logging, and --stacktrace parameters. This commit updates the Gradle pluging to pass these arguments through to the CLI if they were provided to Gradle. All versions of the Smithy CLI support these arguments after 1.0, so this is a safe change regardless of the resolved CLI version.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
