### PR TITLE
Fix modifiesLogging test

### DIFF
--- a/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
+++ b/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
@@ -74,8 +74,7 @@ public class ProjectionTest {
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--info")
                     .build();
-
-            assertThat(result.getOutput(), containsString("[INFO] Validating"));
+            assertThat(result.getOutput(), containsString("[INFO] Smithy validation complete"));
         });
     }
 


### PR DESCRIPTION
https://github.com/awslabs/smithy/pull/1526 updated the logging in the ValidateCommand, changing from `"Validating Smithy model sources"` to `"Smithy validation complete"`, breaking the modifiesLogging integration test. This fixes the test with the updated logging string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
