### PR TITLE
Correclty bind extension to tasks (#72)

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuild.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuild.java
@@ -25,7 +25,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
-import software.amazon.smithy.gradle.SmithyExtension;
 import software.amazon.smithy.gradle.SmithyUtils;
 
 /**
@@ -101,15 +100,6 @@ public abstract class SmithyBuild extends SmithyCliTask {
 
     @TaskAction
     public void execute() {
-        // Configure the task from the extension if things aren't already setup.
-        SmithyExtension extension = SmithyUtils.getSmithyExtension(getProject());
-
-        if (smithyBuildConfigs == null) {
-            getLogger().debug("Setting smithyBuildConfigs of {} to {} from SmithyExtension",
-                              getClass().getName(), extension.getSmithyBuildConfigs());
-            setSmithyBuildConfigs(extension.getSmithyBuildConfigs());
-        }
-
         // Clear out the build directory when rebuilding.
         getProject().delete(getOutputDir());
 

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
@@ -35,7 +35,6 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.workers.WorkerExecutor;
 import software.amazon.smithy.cli.BuildParameterBuilder;
-import software.amazon.smithy.gradle.SmithyExtension;
 import software.amazon.smithy.gradle.SmithyUtils;
 
 /**
@@ -177,23 +176,6 @@ public abstract class SmithyBuildJar extends BaseSmithyTask {
 
     @TaskAction
     public void execute() {
-        // Configure the task from the extension if things aren't already setup.
-        SmithyExtension extension = SmithyUtils.getSmithyExtension(getProject());
-
-        if (projection == null) {
-            getLogger().debug("Setting SmithyBuildJar projection from extension: {}", extension.getProjection());
-            setProjection(extension.getProjection());
-        }
-
-        // Merge tags from the extension into the task.
-        projectionSourceTags.addAll(extension.getProjectionSourceTags());
-
-        // Merge or overwrite?
-        if (smithyBuildConfigs == null) {
-            setSmithyBuildConfigs(extension.getSmithyBuildConfigs());
-            getLogger().debug("Setting SmithyBuildJar smithyBuildConfigs from extension: {}", smithyBuildConfigs);
-        }
-
         writeHeading("Running smithy build");
 
         // Clear out the directories when rebuilding.

--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsTask.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyTagsTask.java
@@ -24,8 +24,6 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.jvm.tasks.Jar;
-import software.amazon.smithy.gradle.SmithyExtension;
-import software.amazon.smithy.gradle.SmithyUtils;
 
 /**
  * Adds Smithy-Tags to the JAR built by the {@link Jar} Task.
@@ -68,10 +66,6 @@ public class SmithyTagsTask extends DefaultTask {
             getLogger().info("'jar' task is not enabled, so nothing to do in 'smithyTags'");
             return;
         }
-
-        // Configure the task from the extension if things aren't already setup.
-        SmithyExtension extension = SmithyUtils.getSmithyExtension(getProject());
-        tags.addAll(extension.getTags());
 
         // Always add the group, the group + ":" + name, and the group + ":" + name + ":" + version as tags.
         if (!getProject().getGroup().toString().isEmpty()) {


### PR DESCRIPTION
Issue #72

*Description of changes:*
Configures the tasks to have their first configuration action to be copying the value from the extension to the task.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
