### PR TITLE
Update dependencies 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,7 @@
 
 import com.github.spotbugs.snom.Effort
 import com.github.spotbugs.snom.SpotBugsTask
-import com.adarshr.gradle.testlogger.TestLoggerExtension;
-import java.nio.charset.Charset
+import com.adarshr.gradle.testlogger.TestLoggerExtension
 
 group = "software.amazon.smithy"
 // Load the version from VERSION File.
@@ -33,8 +32,8 @@ plugins {
     `maven-publish`
     checkstyle
     jacoco
-    id("com.github.spotbugs") version "4.7.1"
-    id("com.gradle.plugin-publish") version "0.11.0"
+    id("com.github.spotbugs") version "5.0.14"
+    id("com.gradle.plugin-publish") version "1.2.0"
     id("com.adarshr.test-logger") version "3.2.0"
 }
 
@@ -143,11 +142,6 @@ repositories {
 publishing {
     publications {
         create<MavenPublication>("pluginMaven") {
-            
-            // Ship the source and javadoc jars.
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["javadocJar"])
-
             pom {
                 description.set(project.description)
                 url.set("https://github.com/awslabs/smithy-gradle-plugin")

--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -19,4 +19,13 @@
     <Match>
         <Class name="~Test\.java$"/>
     </Match>
+
+    <!-- Excessive Defensive copies. -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
*Issue #, if available:* related to #56 (although doesnt resolve)

*Description of changes:*
Updates Dependencies to resolve issues with configuration caching as well as a few other minor warnings.

Also removes the src and javadoc jars from the definition as these are added automatically in the newer versions of the com.gradle.plugin-publish plugin.

*Testing* 
Ran `./gradlew --configuration-cache build` and did not have any errors.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
