### PR TITLE
Make SmithyBuildJar.getOutputDir() public

### DIFF
--- a/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
+++ b/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildJar.java
@@ -69,7 +69,7 @@ public abstract class SmithyBuildJar extends BaseSmithyTask {
      * @return Returns the output directory, lazily evaluated.
      */
     @OutputDirectory
-    abstract DirectoryProperty getOutputDir();
+    public abstract DirectoryProperty getOutputDir();
 
     /**
      * Gets the output directory for running Smithy build.


### PR DESCRIPTION
The other methods that set this property are deprecated, so it seems an oversight that this method is package private.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
